### PR TITLE
#17 - Error when trying to install contrib packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ listed and explained below:
 
 To install for example the `contrib` dependencies run:
     
-    pip install -e .[contrib]
+    pip install -e ".[contrib]"
  
 ## Starting a simple recommender
 


### PR DESCRIPTION
- Quote the command to be save against shells which try to expand the brackets (e.g. zsh)